### PR TITLE
limits for parsing files and archives

### DIFF
--- a/ole2macro.pm
+++ b/ole2macro.pm
@@ -24,7 +24,7 @@ OLE2Macro - Look for Macro Embedded Microsoft Word and Excel Documents
   loadplugin     ole2macro.pm
   body MICROSOFT_OLE2MACRO eval:check_microsoft_ole2macro()
   score MICROSOFT_OLE2MACRO 4
-  
+
 =head1 DESCRIPTION
 
 Detects embedded OLE2 Macros embedded in Word and Excel Documents. Based on:
@@ -56,6 +56,13 @@ my $match_types = qr/(?:xls|ppt|doc|docm|dot|dotm|xlsm|xlsb|pptm|ppsm)$/;
 #Markers in the other in which they should be found.
 my @markers = ("\xd0\xcf\x11\xe0", "\x00\x41\x74\x74\x72\x69\x62\x75\x74\x00");
 
+# limiting the number of files within archive to process
+my $archived_files_process_limit = 3;
+# limiting the amount of bytes read from a file
+my $file_max_read_size = 102400;
+# limiting the amount of bytes read from an archive
+my $archive_max_read_size = 1024000;
+
 # constructor: register the eval rule
 sub new {
   my $class = shift;
@@ -85,7 +92,7 @@ sub _match_markers {
    foreach(@markers){
      if(index($data, $_) > -1){
         $matched++;
-     }else{ 
+     } else {
         last;
      }
    }
@@ -96,42 +103,50 @@ sub _match_markers {
 sub _check_attachments {
   my ($self, $pms) = @_;
 
+  my $processed_files_counter = 0;
   $pms->{nomacro_microsoft_ole2macro} = 0;
 
   foreach my $p ($pms->{msg}->find_parts(qr/./, 1)) {
     my ($ctype, $boundary, $charset, $name) =
       Mail::SpamAssassin::Util::parse_content_type($p->get_header('content-type'));
 
-    my $cte = lc($p->get_header('content-transfer-encoding') || '');
-    $ctype = lc $ctype;
     $name = lc($name || '');
-    if ($cte =~ /base64/){
-      if ($name =~ $match_types){
-          my $contents = $p->decode();
+    if ($name =~ $match_types) {
+          my $contents = $p->decode($file_max_read_size);
           if(_match_markers($contents)){
              $pms->{nomacro_microsoft_ole2macro} = 1;
              last;
           }
-      }elsif($name =~ /(?:zip)$/){
-          my $contents = $p->decode();
+    } elsif ($name =~ /(?:zip)$/) {
+          my $contents = $p->decode($archive_max_read_size);
           my $z = new IO::Uncompress::Unzip \$contents;
 
           my $status;
           my $buff;
-          for ($status = 1; $status > 0; $status = $z->nextStream()){
-             if (lc $z->getHeaderInfo()->{Name} =~ $match_types){
-                my $attachment_data = "";
-                while (($status = $z->read($buff)) > 0) {
-                   $attachment_data .= $buff;
-                }
-                 
-                if(_match_markers($attachment_data)){
-                   $pms->{nomacro_microsoft_ole2macro} = 1;
-                   last;
-                }
+          for ($status = 1; $status > 0; $status = $z->nextStream()) {
+             if (lc $z->getHeaderInfo()->{Name} =~ $match_types) {
+                 $processed_files_counter += 1;
+                 if ($processed_files_counter > $archived_files_process_limit) {
+                     dbg( "Stopping processing archive on file ".$z->getHeaderInfo()->{Name}.": processed files count limit reached\n" );
+                     last;
+                 }
+                 my $attachment_data = "";
+                 my $read_size = 0;
+                 while (($status = $z->read( $buff )) > 0) {
+                     $attachment_data .= $buff;
+                     $read_size += length( $buff );
+                     if ($read_size > $file_max_read_size) {
+                         dbg( "Stopping processing file ".$z->getHeaderInfo()->{Name}." in archive: processed file size overlimit\n" );
+                         last;
+                     }
+                 }
+
+                 if (_match_markers( $attachment_data )) {
+                     $pms->{nomacro_microsoft_ole2macro} = 1;
+                     last;
+                 }
              }
           }
-      }
     }
   }
 }


### PR DESCRIPTION
Large attachments cause errors "exceeded time limit in
Mail::SpamAssassin::Plugin::Check:"
- limiting number of files within archive to process (default 3 files)
- limit the buffer size to check (default 100k)
- limit the archive part size to extract (default 1m)

Removed the check for content-transfer-encoding, as it opens a hole if
a spammer uses non-base64 encoding (qp, binary). And the
Mail::SpamAssassin::Message::Node::decode takes care of the CTE automatically.
